### PR TITLE
feature/add source command

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,5 +1,7 @@
 BOT_TOKEN=your_token_here
 
+GITHUB_URL=https://github.com/Xithrius/Xythrion
+
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=placeholder
 POSTGRES_DB=postgres

--- a/xythrion/__main__.py
+++ b/xythrion/__main__.py
@@ -1,5 +1,5 @@
 import logging
-from os import listdir, remove
+from os import listdir, mkdir, remove
 from pathlib import Path
 
 import discord
@@ -8,6 +8,9 @@ from discord.ext.commands import when_mentioned_or
 from xythrion.bot import Xythrion
 from xythrion.extensions import EXTENSIONS
 from .constants import Config
+
+if not Path.cwd().exists:
+    mkdir(Path.cwd() / 'tmp')
 
 log = logging.getLogger(__name__)
 

--- a/xythrion/constants.py
+++ b/xythrion/constants.py
@@ -7,6 +7,7 @@ __all__ = ('Config', 'Postgresql', 'WeatherAPIs')
 class Config(NamedTuple):
     TOKEN = environ.get('BOT_TOKEN')
     BOT_DESCRIPTION = environ.get('BOT_DESCRIPTION', 'Graphing manipulated data through discord.py')
+    GITHUB_URL = environ.get('GITHUB_URL')
 
 
 class Postgresql(NamedTuple):

--- a/xythrion/extensions/meta/__init__.py
+++ b/xythrion/extensions/meta/__init__.py
@@ -3,6 +3,7 @@ from xythrion.extensions.meta.dates import Dates
 from xythrion.extensions.meta.guilds import Guilds
 from xythrion.extensions.meta.help import Help
 from xythrion.extensions.meta.links import Links
+from xythrion.extensions.meta.source import Source
 
 
 def setup(bot: Xythrion) -> None:
@@ -11,3 +12,4 @@ def setup(bot: Xythrion) -> None:
     bot.add_cog(Guilds(bot))
     bot.add_cog(Help(bot))
     bot.add_cog(Links(bot))
+    bot.add_cog(Source(bot))

--- a/xythrion/extensions/meta/source.py
+++ b/xythrion/extensions/meta/source.py
@@ -5,26 +5,26 @@ from pathlib import Path
 from typing import Optional, Tuple, Union
 
 from discord import Colour, Embed
-from discord.ext import commands
+from discord.ext import commands as comms
 
 from xythrion.constants import Config
 
 GITHUB_URL = Config.GITHUB_URL
 
 SourceType = Union[
-    commands.HelpCommand,
-    commands.Command,
-    commands.Cog,
+    comms.HelpCommand,
+    comms.Command,
+    comms.Cog,
     str,
-    commands.ExtensionNotLoaded,
+    comms.ExtensionNotLoaded,
 ]
 
 
-class SourceConverter(commands.Converter):
+class SourceConverter(comms.Converter):
     """Convert an argument into a help command, tag, command, or cog."""
 
     # special thanks to Pydis
-    async def convert(self, ctx: commands.Context, argument: str) -> SourceType:
+    async def convert(self, ctx: comms.Context, argument: str) -> SourceType:
         """Convert argument into source object."""
         if argument.lower().startswith("help"):
             return ctx.bot.help_command
@@ -45,14 +45,14 @@ class SourceConverter(commands.Converter):
         elif argument.lower() in tags_cog._cache:
             return argument.lower()
 
-        raise commands.BadArgument(
+        raise comms.BadArgument(
             f"Unable to convert '{argument}' to valid command{', tag,' if show_tag else ''} or Cog."
         )
 
     @staticmethod
     def get_source_location(src_obj: SourceType) -> Tuple[str, str, Optional[int]]:
         """Attemps to get the source of a command and build the URL."""
-        if isinstance(src_obj, commands.Command):
+        if isinstance(src_obj, comms.Command):
             src = src_obj.callback.__code__
             filename = src.co_filename
         else:
@@ -61,13 +61,13 @@ class SourceConverter(commands.Converter):
             try:
                 filename = inspect.getsourcefile(src)
             except TypeError:
-                raise commands.BadArgument("Cannot get source for a dynamically-created object.")
+                raise comms.BadArgument("Cannot get source for a dynamically-created object.")
 
         if not isinstance(src_obj, str):
             try:
                 lines, first_line_no = inspect.getsourcelines(src)
             except OSError:
-                raise commands.BadArgument("Cannot get source for a dynamically-created object.")
+                raise comms.BadArgument("Cannot get source for a dynamically-created object.")
 
             lines_extension = f"#L{first_line_no}-L{first_line_no + len(lines) - 1}"
         else:
@@ -81,14 +81,14 @@ class SourceConverter(commands.Converter):
         return url, file_location, first_line_no or None
 
 
-class Source(commands.Cog):
+class Source(comms.Cog):
     """Command to send the source (github repo) of a command."""
 
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: comms.Bot):
         self.bot = bot
 
-    @commands.command(name="source", brief="Send a link to Xythrion's GitHub repo")
-    async def send_source(self, ctx: commands.Context, arg1: str = "") -> None:
+    @comms.command(name="source", brief="Send a link to Xythrion's GitHub repo")
+    async def send_source(self, ctx: comms.Context, arg1: str = "") -> None:
         """Send the source GitGub url in an embed."""
         src_conv = SourceConverter()
         if arg1:
@@ -111,7 +111,7 @@ class Source(commands.Cog):
                     value=f"[Go To GitHub]({src_url})",
                 )
                 await ctx.send(embed=embed)
-            except commands.BadArgument as e:
+            except comms.BadArgument as e:
                 raise e
         else:
             embed = Embed(title="Xythrion's GitHub Repo", colour=Colour.blue())
@@ -119,8 +119,3 @@ class Source(commands.Cog):
                 name="Repository", value=f"[Go To GitHub]({GITHUB_URL})"
             )
             await ctx.send(embed=embed)
-
-
-def setup(bot: commands.Bot) -> None:
-    """Load the Source cog."""
-    bot.add_cog(Source(bot))

--- a/xythrion/extensions/meta/source.py
+++ b/xythrion/extensions/meta/source.py
@@ -1,0 +1,126 @@
+"""Command to get a link to the source repo for this project."""
+import inspect
+
+from pathlib import Path
+from typing import Optional, Tuple, Union
+
+from discord import Colour, Embed
+from discord.ext import commands
+
+from xythrion.constants import Config
+
+GITHUB_URL = Config.GITHUB_URL
+
+SourceType = Union[
+    commands.HelpCommand,
+    commands.Command,
+    commands.Cog,
+    str,
+    commands.ExtensionNotLoaded,
+]
+
+
+class SourceConverter(commands.Converter):
+    """Convert an argument into a help command, tag, command, or cog."""
+
+    # special thanks to Pydis
+    async def convert(self, ctx: commands.Context, argument: str) -> SourceType:
+        """Convert argument into source object."""
+        if argument.lower().startswith("help"):
+            return ctx.bot.help_command
+
+        cog = ctx.bot.get_cog(argument)
+        if cog:
+            return cog
+
+        cmd = ctx.bot.get_command(argument)
+        if cmd:
+            return cmd
+
+        tags_cog = ctx.bot.get_cog("Tags")
+        show_tag = True
+
+        if not tags_cog:
+            show_tag = False
+        elif argument.lower() in tags_cog._cache:
+            return argument.lower()
+
+        raise commands.BadArgument(
+            f"Unable to convert `{argument}` to valid command{', tag,' if show_tag else ''} or Cog."
+        )
+
+    @staticmethod
+    def get_source_location(src_obj: SourceType) -> Tuple[str, str, Optional[int]]:
+        """Attemps to get the source of a command and build the URL."""
+        if isinstance(src_obj, commands.Command):
+            src = src_obj.callback.__code__
+            filename = src.co_filename
+        else:
+            src = type(src_obj)
+
+            try:
+                filename = inspect.getsourcefile(src)
+            except TypeError:
+                raise commands.BadArgument("Cannot get source for a dynamically-created object.")
+
+        if not isinstance(src_obj, str):
+            try:
+                lines, first_line_no = inspect.getsourcelines(src)
+            except OSError:
+                raise commands.BadArgument("Cannot get source for a dynamically-created object.")
+
+            lines_extension = f"#L{first_line_no}-L{first_line_no + len(lines) - 1}"
+        else:
+            first_line_no = None
+            lines_extension = ""
+
+        file_location = Path(filename).relative_to(Path.cwd()).as_posix()
+
+        url = f"{GITHUB_URL}/blob/master/{file_location}{lines_extension}"
+
+        return url, file_location, first_line_no or None
+
+
+class Source(commands.Cog):
+    """Command to send the source (github repo) of a command."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.command(name="source", brief="Send a link to Xythrion's GitHub repo")
+    async def send_source(self, ctx: commands.Context, arg1: str = "") -> None:
+        """Send the source GitGub url in an embed."""
+        src_conv = SourceConverter()
+        if arg1:
+            try:
+                src_obj = await src_conv.convert(ctx, arg1)
+                src_url = src_conv.get_source_location(src_obj)[0]
+
+                if hasattr(src_obj, 'brief'):
+                    desc = f"Description: {src_obj.brief}"
+                else:
+                    desc = "Extension"
+
+                embed = Embed(
+                    title="Xythrion's GitHub Repo",
+                    colour=Colour.blue(),
+                    description=desc,
+                )
+                embed.add_field(
+                    name="Repository",
+                    value=f"[Go To GitHub]({src_url})",
+                )
+                await ctx.send(embed=embed)
+            except commands.BadArgument as e:
+                raise e
+        else:
+            embed = Embed(title="Xythrion's GitHub Repo", colour=Colour.blue())
+            embed.add_field(
+                name="Repository", value=f"[Go To GitHub]({GITHUB_URL})"
+            )
+            await ctx.send(embed=embed)
+
+
+def setup(bot: commands.Bot) -> None:
+    """Load the Source cog."""
+    bot.add_cog(Source(bot))

--- a/xythrion/extensions/meta/source.py
+++ b/xythrion/extensions/meta/source.py
@@ -46,7 +46,7 @@ class SourceConverter(commands.Converter):
             return argument.lower()
 
         raise commands.BadArgument(
-            f"Unable to convert `{argument}` to valid command{', tag,' if show_tag else ''} or Cog."
+            f"Unable to convert '{argument}' to valid command{', tag,' if show_tag else ''} or Cog."
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary
This command links to the code of a command if it can be found. The embed could use a little work as it returns an empty description, this description shoul dbe the  of a command. There is a known issue with the embed where entering an invalid cog name raises an exception, that exception escapes the markdown in the embed, it is mildly annoying.

## Usage
`\source` to get the generic repo or `\source [command]` to get the cog source
![image](https://user-images.githubusercontent.com/39353605/97096076-d9446b80-161b-11eb-91e8-4e0578f4257d.png)

## Needs fixing
Missing description (this attempts to get the command `brief`)
![image](https://user-images.githubusercontent.com/39353605/97096082-e95c4b00-161b-11eb-840d-19b5ec3ace6d.png)

Closes: #8 