### PR TITLE
chore: remove reconnect and bot constructor args

### DIFF
--- a/xythrion/__main__.py
+++ b/xythrion/__main__.py
@@ -16,4 +16,4 @@ for extension in EXTENSIONS:
     bot.load_extension(extension)
     log.trace(f'Loaded extension "{extension}"')
 
-bot.run(Config.TOKEN, bot=True, reconnect=True)
+bot.run(Config.TOKEN)


### PR DESCRIPTION
Neither are required anymore since a long time ago in discord.py (and indeed selfbot support is due to be removed in d.py soon)