### PR TITLE
Class-based CRUD operations in the API

### DIFF
--- a/api/app/database/base.py
+++ b/api/app/database/base.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import DeclarativeBase, declared_attr
 
 from .meta import meta
 
@@ -7,3 +7,10 @@ class Base(DeclarativeBase):
     """Base for all models."""
 
     metadata = meta
+
+
+class MappedBase(DeclarativeBase):
+    @classmethod
+    @declared_attr.directive
+    def __tablename__(cls) -> str:
+        return cls.__name__.lower()

--- a/api/app/database/crud/base.py
+++ b/api/app/database/crud/base.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Generic, TypeVar
 from uuid import UUID
 
@@ -26,6 +27,11 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
 
         return result.scalars().first()
 
+    # async def get_by_(self, db: AsyncSession, **kwargs) -> ModelType | None:
+    #     result = await db.execute(
+    #         select(self.model).where(and_(*kwargs))
+    #     )
+
     async def create_(
         self,
         db: AsyncSession,
@@ -40,9 +46,9 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         self,
         db: AsyncSession,
         *,
-        pk: int | UUID,
+        pk: list[int | UUID] | Callable,
     ) -> int:
-        result = await db.execute(delete(self.model).where(self.model.id == pk))
+        result = await db.execute(delete(self.model).where(self.model.id.in_(pk) if isinstance(pk, list) else pk()))
 
         return result.rowcount
 

--- a/api/app/database/crud/base.py
+++ b/api/app/database/crud/base.py
@@ -1,0 +1,63 @@
+from typing import Generic, TypeVar
+from uuid import UUID
+
+from pydantic import BaseModel
+from sqlalchemy import and_, delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.base import MappedBase
+
+ModelType = TypeVar("ModelType", bound=MappedBase)
+CreateSchemaType = TypeVar("CreateSchemaType", bound=BaseModel)
+UpdateSchemaType = TypeVar("UpdateSchemaType", bound=BaseModel)
+
+
+class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
+    def __init__(self, model: type[ModelType]) -> None:
+        self.model = model
+
+    async def get_(
+        self,
+        db: AsyncSession,
+        *,
+        pk: int | UUID | None = None,
+    ) -> ModelType | None:
+        result = await db.execute(select(self.model).where(and_(self.model.id == pk)))
+
+        return result.scalars().first()
+
+    async def create_(
+        self,
+        db: AsyncSession,
+        *,
+        obj_in: CreateSchemaType,
+    ) -> None:
+        create_data = self.model(**obj_in.model_dump())
+
+        db.add(create_data)
+
+    async def delete_(
+        self,
+        db: AsyncSession,
+        *,
+        pk: int | UUID,
+    ) -> int:
+        result = await db.execute(delete(self.model).where(self.model.id == pk))
+
+        return result.rowcount
+
+    # async def update_(
+    #     self,
+    #     db: AsyncSession,
+    #     pk: int,
+    #     obj_in: UpdateSchemaType | dict[str, Any],
+    #     user_id: int | None = None,
+    # ) -> int:
+    #     if isinstance(obj_in, dict):
+    #         update_data = obj_in
+    #     else:
+    #         update_data = obj_in.model_dump(exclude_unset=True)
+    #     if user_id:
+    #         update_data.update({"update_user": user_id})
+    #     result = await db.execute(update(self.model).where(self.model.id == pk).values(**update_data))
+    #     return result.rowcount

--- a/api/app/database/crud/command_metric.py
+++ b/api/app/database/crud/command_metric.py
@@ -1,31 +1,78 @@
-from typing import Annotated
+from collections.abc import Sequence
+from uuid import UUID
 
-from app.routers.command_metric.schemas import CommandMetricCreate
-from fastapi import Depends
-from sqlalchemy import select
+from sqlalchemy import Select, and_, delete, desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database.dependencies import get_db_session
+from app.database.crud.base import CRUDBase
 from app.database.models.command_metric import CommandMetricModel
+from app.routers.command_metric.schemas import CommandMetricCreate, CommandMetricUpdate
 
 
-class CommandMetricCRUD:
-    def __init__(self, session: Annotated[AsyncSession, Depends(get_db_session)]) -> None:
-        self.session = session
+class CommandMetricCRUD(CRUDBase[CommandMetricModel, CommandMetricCreate, CommandMetricUpdate]):
+    async def get(self, db: AsyncSession, *, pk: UUID) -> CommandMetricModel | None:
+        return await self.get_(db, pk=pk)
 
-    async def create_command_metric(self, item: CommandMetricCreate) -> None:
-        self.session.add(CommandMetricModel(**item.model_dump()))
+    async def get_list(
+        self,
+        command_name: str | None = None,
+        successfully_completed: bool | None = None,
+    ) -> Select:
+        se = select(self.model).order_by(desc(self.model.used_at))
 
-    async def get_all_command_metrics(self, limit: int, offset: int) -> list[CommandMetricModel]:
-        raw_items = await self.session.execute(
-            select(CommandMetricModel).limit(limit).offset(offset),
-        )
+        where_list = []
 
-        return list(raw_items.scalars().fetchall())
+        if command_name:
+            where_list.append(self.model.command_name.like(f"%{command_name}%"))
+        if successfully_completed is not None:
+            where_list.append(self.model.successfully_completed == successfully_completed)
 
-    # async def filter(self, name: str | None = None) -> list[CommandMetricModel]:
-    #     query = select(CommandMetricModel)
-    #     if name:
-    #         query = query.where(CommandMetricModel.name == name)
-    #     rows = await self.session.execute(query)
-    #     return list(rows.scalars().fetchall())
+        if where_list:
+            se = se.where(and_(*where_list))
+
+        return se
+
+    async def get_all(self, db: AsyncSession, *, limit: int, offset: int) -> Sequence[CommandMetricModel]:
+        items = await db.execute(select(self.model).limit(limit).offset(offset))
+
+        return items.scalars().all()
+
+    async def get_by_command_name(self, db: AsyncSession, *, command_name: str) -> CommandMetricModel | None:
+        items = await db.execute(select(self.model).where(self.model.command_name == command_name))
+
+        return items.scalars().first()
+
+    async def create(self, db: AsyncSession, *, obj_in: CommandMetricCreate) -> CommandMetricModel:
+        new_item = await self.create_(db, obj_in=obj_in)
+
+        return new_item
+
+    async def delete(self, db: AsyncSession, *, pk: list[UUID]) -> int:
+        items = await db.execute(delete(self.model).where(self.model.id.in_(pk)))
+
+        return items.rowcount
+
+
+command_metric_dao: CommandMetricCRUD = CommandMetricCRUD(CommandMetricModel)
+
+
+# class CommandMetricCRUD:
+#     def __init__(self, session: Annotated[AsyncSession, Depends(get_db_session)]) -> None:
+#         self.session = session
+
+#     async def create_command_metric(self, item: CommandMetricCreate) -> None:
+#         self.session.add(CommandMetricModel(**item.model_dump()))
+
+#     async def get_all_command_metrics(self, limit: int, offset: int) -> list[CommandMetricModel]:
+#         raw_items = await self.session.execute(
+#             select(CommandMetricModel).limit(limit).offset(offset),
+#         )
+
+#         return list(raw_items.scalars().fetchall())
+
+# async def filter(self, name: str | None = None) -> list[CommandMetricModel]:
+#     query = select(CommandMetricModel)
+#     if name:
+#         query = query.where(CommandMetricModel.name == name)
+#     rows = await self.session.execute(query)
+#     return list(rows.scalars().fetchall())

--- a/api/app/database/crud/command_metric.py
+++ b/api/app/database/crud/command_metric.py
@@ -24,9 +24,7 @@ class CommandMetricCRUD(CRUDBase[CommandMetricModel, CommandMetricCreate, Comman
         return items.scalars().first()
 
     async def create(self, db: AsyncSession, *, obj_in: CommandMetricCreate) -> CommandMetricModel:
-        new_item = await self.create_(db, obj_in=obj_in)
-
-        return new_item
+        await self.create_(db, obj_in=obj_in)
 
     async def delete(self, db: AsyncSession, *, pk: list[UUID]) -> int:
         items = await db.execute(delete(self.model).where(self.model.id.in_(pk)))

--- a/api/app/database/crud/command_metric.py
+++ b/api/app/database/crud/command_metric.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.crud.base import CRUDBase
@@ -27,9 +27,7 @@ class CommandMetricCRUD(CRUDBase[CommandMetricModel, CommandMetricCreate, Comman
         await self.create_(db, obj_in=obj_in)
 
     async def delete(self, db: AsyncSession, *, pk: list[UUID]) -> int:
-        items = await db.execute(delete(self.model).where(self.model.id.in_(pk)))
-
-        return items.rowcount
+        return await self.delete_(db, pk=pk)
 
 
 command_metric_dao = CommandMetricCRUD(CommandMetricModel)

--- a/api/app/database/crud/command_metric.py
+++ b/api/app/database/crud/command_metric.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import Select, and_, delete, desc, select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.crud.base import CRUDBase
@@ -12,25 +12,6 @@ from app.routers.command_metric.schemas import CommandMetricCreate, CommandMetri
 class CommandMetricCRUD(CRUDBase[CommandMetricModel, CommandMetricCreate, CommandMetricUpdate]):
     async def get(self, db: AsyncSession, *, pk: UUID) -> CommandMetricModel | None:
         return await self.get_(db, pk=pk)
-
-    async def get_list(
-        self,
-        command_name: str | None = None,
-        successfully_completed: bool | None = None,
-    ) -> Select:
-        se = select(self.model).order_by(desc(self.model.used_at))
-
-        where_list = []
-
-        if command_name:
-            where_list.append(self.model.command_name.like(f"%{command_name}%"))
-        if successfully_completed is not None:
-            where_list.append(self.model.successfully_completed == successfully_completed)
-
-        if where_list:
-            se = se.where(and_(*where_list))
-
-        return se
 
     async def get_all(self, db: AsyncSession, *, limit: int, offset: int) -> Sequence[CommandMetricModel]:
         items = await db.execute(select(self.model).limit(limit).offset(offset))
@@ -53,26 +34,4 @@ class CommandMetricCRUD(CRUDBase[CommandMetricModel, CommandMetricCreate, Comman
         return items.rowcount
 
 
-command_metric_dao: CommandMetricCRUD = CommandMetricCRUD(CommandMetricModel)
-
-
-# class CommandMetricCRUD:
-#     def __init__(self, session: Annotated[AsyncSession, Depends(get_db_session)]) -> None:
-#         self.session = session
-
-#     async def create_command_metric(self, item: CommandMetricCreate) -> None:
-#         self.session.add(CommandMetricModel(**item.model_dump()))
-
-#     async def get_all_command_metrics(self, limit: int, offset: int) -> list[CommandMetricModel]:
-#         raw_items = await self.session.execute(
-#             select(CommandMetricModel).limit(limit).offset(offset),
-#         )
-
-#         return list(raw_items.scalars().fetchall())
-
-# async def filter(self, name: str | None = None) -> list[CommandMetricModel]:
-#     query = select(CommandMetricModel)
-#     if name:
-#         query = query.where(CommandMetricModel.name == name)
-#     rows = await self.session.execute(query)
-#     return list(rows.scalars().fetchall())
+command_metric_dao = CommandMetricCRUD(CommandMetricModel)

--- a/api/app/database/crud/command_metric.py
+++ b/api/app/database/crud/command_metric.py
@@ -1,0 +1,31 @@
+from typing import Annotated
+
+from app.routers.command_metric.schemas import CommandMetricCreate
+from fastapi import Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.dependencies import get_db_session
+from app.database.models.command_metric import CommandMetricModel
+
+
+class CommandMetricCRUD:
+    def __init__(self, session: Annotated[AsyncSession, Depends(get_db_session)]) -> None:
+        self.session = session
+
+    async def create_command_metric(self, item: CommandMetricCreate) -> None:
+        self.session.add(CommandMetricModel(**item.model_dump()))
+
+    async def get_all_command_metrics(self, limit: int, offset: int) -> list[CommandMetricModel]:
+        raw_items = await self.session.execute(
+            select(CommandMetricModel).limit(limit).offset(offset),
+        )
+
+        return list(raw_items.scalars().fetchall())
+
+    # async def filter(self, name: str | None = None) -> list[CommandMetricModel]:
+    #     query = select(CommandMetricModel)
+    #     if name:
+    #         query = query.where(CommandMetricModel.name == name)
+    #     rows = await self.session.execute(query)
+    #     return list(rows.scalars().fetchall())

--- a/api/app/database/crud/link_map_channel.py
+++ b/api/app/database/crud/link_map_channel.py
@@ -13,20 +13,19 @@ class LinkMapChannelCRUD(CRUDBase[LinkMapChannelModel, LinkMapChannelCreate, Lin
     async def get(self, db: AsyncSession, *, pk: UUID) -> LinkMapChannelModel | None:
         return await self.get_(db, pk=pk)
 
-    async def get_all(self, db: AsyncSession, *, limit: int, offset: int) -> Sequence[LinkMapChannelModel]:
-        items = await db.execute(select(self.model).limit(limit).offset(offset))
+    async def get_all(self, db: AsyncSession) -> Sequence[LinkMapChannelModel]:
+        items = await db.execute(select(self.model))
+        items.unique()
 
         return items.scalars().all()
 
-    async def get_by_command_name(self, db: AsyncSession, *, command_name: str) -> LinkMapChannelModel | None:
-        items = await db.execute(select(self.model).where(self.model.command_name == command_name))
+    async def get_by_server_id(self, db: AsyncSession, *, server_id: int) -> LinkMapChannelModel | None:
+        items = await db.execute(select(self.model).where(self.model.server_id == server_id))
 
         return items.scalars().first()
 
     async def create(self, db: AsyncSession, *, obj_in: LinkMapChannelCreate) -> LinkMapChannelModel:
-        new_item = await self.create_(db, obj_in=obj_in)
-
-        return new_item
+        await self.create_(db, obj_in=obj_in)
 
     async def delete(self, db: AsyncSession, *, pk: list[UUID]) -> int:
         items = await db.execute(delete(self.model).where(self.model.id.in_(pk)))

--- a/api/app/database/crud/link_map_channel.py
+++ b/api/app/database/crud/link_map_channel.py
@@ -1,0 +1,15 @@
+from typing import Annotated, Any
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.dependencies import get_db_session
+
+
+class LinkMapChannelCRUD:
+    def __init__(self, session: Annotated[AsyncSession, Depends(get_db_session)]) -> None:
+        self.session = session
+
+    async def create_(self, item: Any) -> None:
+        # self.session.add(...(**item.model_dump()))
+        ...

--- a/api/app/database/crud/link_map_channel.py
+++ b/api/app/database/crud/link_map_channel.py
@@ -1,15 +1,37 @@
-from typing import Annotated, Any
+from collections.abc import Sequence
+from uuid import UUID
 
-from fastapi import Depends
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database.dependencies import get_db_session
+from app.database.crud.base import CRUDBase
+from app.database.models.link_map import LinkMapChannelModel
+from app.routers.link_map.schemas import LinkMapChannelCreate, LinkMapChannelUpdate
 
 
-class LinkMapChannelCRUD:
-    def __init__(self, session: Annotated[AsyncSession, Depends(get_db_session)]) -> None:
-        self.session = session
+class LinkMapChannelCRUD(CRUDBase[LinkMapChannelModel, LinkMapChannelCreate, LinkMapChannelUpdate]):
+    async def get(self, db: AsyncSession, *, pk: UUID) -> LinkMapChannelModel | None:
+        return await self.get_(db, pk=pk)
 
-    async def create_(self, item: Any) -> None:
-        # self.session.add(...(**item.model_dump()))
-        ...
+    async def get_all(self, db: AsyncSession, *, limit: int, offset: int) -> Sequence[LinkMapChannelModel]:
+        items = await db.execute(select(self.model).limit(limit).offset(offset))
+
+        return items.scalars().all()
+
+    async def get_by_command_name(self, db: AsyncSession, *, command_name: str) -> LinkMapChannelModel | None:
+        items = await db.execute(select(self.model).where(self.model.command_name == command_name))
+
+        return items.scalars().first()
+
+    async def create(self, db: AsyncSession, *, obj_in: LinkMapChannelCreate) -> LinkMapChannelModel:
+        new_item = await self.create_(db, obj_in=obj_in)
+
+        return new_item
+
+    async def delete(self, db: AsyncSession, *, pk: list[UUID]) -> int:
+        items = await db.execute(delete(self.model).where(self.model.id.in_(pk)))
+
+        return items.rowcount
+
+
+link_map_channel_dao = LinkMapChannelCRUD(LinkMapChannelModel)

--- a/api/app/database/crud/link_map_converter.py
+++ b/api/app/database/crud/link_map_converter.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.crud.base import CRUDBase
@@ -24,14 +24,10 @@ class LinkMapConverterCRUD(CRUDBase[LinkMapConverterModel, LinkMapConverterCreat
         return items.scalars().all()
 
     async def create(self, db: AsyncSession, *, obj_in: LinkMapConverterCreate) -> LinkMapConverterModel:
-        new_item = await self.create_(db, obj_in=obj_in)
-
-        return new_item
+        await self.create_(db, obj_in=obj_in)
 
     async def delete(self, db: AsyncSession, *, pk: list[UUID]) -> int:
-        items = await db.execute(delete(self.model).where(self.model.id.in_(pk)))
-
-        return items.rowcount
+        return await self.delete_(db, pk=pk)
 
 
 link_map_converter_dao = LinkMapConverterCRUD(LinkMapConverterModel)

--- a/api/app/database/crud/link_map_converter.py
+++ b/api/app/database/crud/link_map_converter.py
@@ -1,0 +1,15 @@
+from typing import Annotated, Any
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.dependencies import get_db_session
+
+
+class LinkMapConverterCRUD:
+    def __init__(self, session: Annotated[AsyncSession, Depends(get_db_session)]) -> None:
+        self.session = session
+
+    async def create_(self, item: Any) -> None:
+        # self.session.add(...(**item.model_dump()))
+        ...

--- a/api/app/database/crud/link_map_converter.py
+++ b/api/app/database/crud/link_map_converter.py
@@ -1,15 +1,37 @@
-from typing import Annotated, Any
+from collections.abc import Sequence
+from uuid import UUID
 
-from fastapi import Depends
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database.dependencies import get_db_session
+from app.database.crud.base import CRUDBase
+from app.database.models.link_map import LinkMapConverterModel
+from app.routers.link_map.schemas import LinkMapConverterCreate, LinkMapConverterUpdate
 
 
-class LinkMapConverterCRUD:
-    def __init__(self, session: Annotated[AsyncSession, Depends(get_db_session)]) -> None:
-        self.session = session
+class LinkMapConverterCRUD(CRUDBase[LinkMapConverterModel, LinkMapConverterCreate, LinkMapConverterUpdate]):
+    async def get(self, db: AsyncSession, *, pk: UUID) -> LinkMapConverterModel | None:
+        return await self.get_(db, pk=pk)
 
-    async def create_(self, item: Any) -> None:
-        # self.session.add(...(**item.model_dump()))
-        ...
+    async def get_all(self, db: AsyncSession, *, limit: int, offset: int) -> Sequence[LinkMapConverterModel]:
+        items = await db.execute(select(self.model).limit(limit).offset(offset))
+
+        return items.scalars().all()
+
+    async def get_by_command_name(self, db: AsyncSession, *, command_name: str) -> LinkMapConverterModel | None:
+        items = await db.execute(select(self.model).where(self.model.command_name == command_name))
+
+        return items.scalars().first()
+
+    async def create(self, db: AsyncSession, *, obj_in: LinkMapConverterCreate) -> LinkMapConverterModel:
+        new_item = await self.create_(db, obj_in=obj_in)
+
+        return new_item
+
+    async def delete(self, db: AsyncSession, *, pk: list[UUID]) -> int:
+        items = await db.execute(delete(self.model).where(self.model.id.in_(pk)))
+
+        return items.rowcount
+
+
+link_map_converter_dao = LinkMapConverterCRUD(LinkMapConverterModel)

--- a/api/app/database/crud/link_map_converter.py
+++ b/api/app/database/crud/link_map_converter.py
@@ -18,10 +18,10 @@ class LinkMapConverterCRUD(CRUDBase[LinkMapConverterModel, LinkMapConverterCreat
 
         return items.scalars().all()
 
-    async def get_by_command_name(self, db: AsyncSession, *, command_name: str) -> LinkMapConverterModel | None:
-        items = await db.execute(select(self.model).where(self.model.command_name == command_name))
+    async def get_by_server_id(self, db: AsyncSession, *, server_id: str) -> Sequence[LinkMapConverterModel]:
+        items = await db.execute(select(self.model).where(self.model.channel_map_server_id == server_id))
 
-        return items.scalars().first()
+        return items.scalars().all()
 
     async def create(self, db: AsyncSession, *, obj_in: LinkMapConverterCreate) -> LinkMapConverterModel:
         new_item = await self.create_(db, obj_in=obj_in)

--- a/api/app/database/crud/pin.py
+++ b/api/app/database/crud/pin.py
@@ -1,0 +1,15 @@
+from typing import Annotated, Any
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.dependencies import get_db_session
+
+
+class PinCRUD:
+    def __init__(self, session: Annotated[AsyncSession, Depends(get_db_session)]) -> None:
+        self.session = session
+
+    async def create_(self, item: Any) -> None:
+        # self.session.add(...(**item.model_dump()))
+        ...

--- a/api/app/database/crud/pin.py
+++ b/api/app/database/crud/pin.py
@@ -1,15 +1,37 @@
-from typing import Annotated, Any
+from collections.abc import Sequence
+from uuid import UUID
 
-from fastapi import Depends
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database.dependencies import get_db_session
+from app.database.crud.base import CRUDBase
+from app.database.models.pin import PinModel
+from app.routers.pin.schemas import PinCreate, PinUpdate
 
 
-class PinCRUD:
-    def __init__(self, session: Annotated[AsyncSession, Depends(get_db_session)]) -> None:
-        self.session = session
+class PinCRUD(CRUDBase[PinModel, PinCreate, PinUpdate]):
+    async def get(self, db: AsyncSession, *, pk: UUID) -> PinModel | None:
+        return await self.get_(db, pk=pk)
 
-    async def create_(self, item: Any) -> None:
-        # self.session.add(...(**item.model_dump()))
-        ...
+    async def get_all(self, db: AsyncSession, *, limit: int, offset: int) -> Sequence[PinModel]:
+        items = await db.execute(select(self.model).limit(limit).offset(offset))
+
+        return items.scalars().all()
+
+    # async def get_by_command_name(self, db: AsyncSession, *, command_name: str) -> PinModel | None:
+    #     items = await db.execute(select(self.model).where(self.model.command_name == command_name))
+
+    #     return items.scalars().first()
+
+    async def create(self, db: AsyncSession, *, obj_in: PinCreate) -> PinModel:
+        new_item = await self.create_(db, obj_in=obj_in)
+
+        return new_item
+
+    async def delete(self, db: AsyncSession, *, pk: list[UUID]) -> int:
+        items = await db.execute(delete(self.model).where(self.model.id.in_(pk)))
+
+        return items.rowcount
+
+
+pin_dao = PinCRUD(PinModel)

--- a/api/app/database/crud/pin.py
+++ b/api/app/database/crud/pin.py
@@ -1,37 +1,40 @@
 from collections.abc import Sequence
-from uuid import UUID
+from typing import Generic, TypeVar
 
-from sqlalchemy import delete, select
+from sqlalchemy import ColumnElement, and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.crud.base import CRUDBase
 from app.database.models.pin import PinModel
-from app.routers.pin.schemas import PinCreate, PinUpdate
+from app.routers.pin.schemas import PinBase, PinCreate, PinUpdate
+
+PinType = TypeVar("PinType", bound=PinBase)
+
+
+def equivalent_pin_model(pin: Generic[PinType]) -> ColumnElement[bool]:
+    return and_(
+        PinModel.server_id == pin.server_id,
+        PinModel.channel_id == pin.channel_id,
+        PinModel.message_id == pin.message_id,
+    )
 
 
 class PinCRUD(CRUDBase[PinModel, PinCreate, PinUpdate]):
-    async def get(self, db: AsyncSession, *, pk: UUID) -> PinModel | None:
-        return await self.get_(db, pk=pk)
-
     async def get_all(self, db: AsyncSession, *, limit: int, offset: int) -> Sequence[PinModel]:
         items = await db.execute(select(self.model).limit(limit).offset(offset))
 
         return items.scalars().all()
 
-    # async def get_by_command_name(self, db: AsyncSession, *, command_name: str) -> PinModel | None:
-    #     items = await db.execute(select(self.model).where(self.model.command_name == command_name))
+    async def get_by_section_ids(self, db: AsyncSession, *, pin: PinCreate) -> PinModel | None:
+        items = await db.execute(select(PinModel).where(equivalent_pin_model(pin)))
 
-    #     return items.scalars().first()
+        return items.scalars().first()
 
     async def create(self, db: AsyncSession, *, obj_in: PinCreate) -> PinModel:
-        new_item = await self.create_(db, obj_in=obj_in)
+        await self.create_(db, obj_in=obj_in)
 
-        return new_item
-
-    async def delete(self, db: AsyncSession, *, pk: list[UUID]) -> int:
-        items = await db.execute(delete(self.model).where(self.model.id.in_(pk)))
-
-        return items.rowcount
+    async def delete(self, db: AsyncSession, *, pin: PinBase) -> int:
+        return await self.delete_(db, pk=lambda: equivalent_pin_model(pin))
 
 
 pin_dao = PinCRUD(PinModel)

--- a/api/app/database/crud/trusted.py
+++ b/api/app/database/crud/trusted.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.crud.base import CRUDBase
@@ -18,20 +18,16 @@ class TrustedCRUD(CRUDBase[TrustedModel, TrustedCreate, TrustedUpdate]):
 
         return items.scalars().all()
 
-    # async def get_by_command_name(self, db: AsyncSession, *, command_name: str) -> TrustedModel | None:
-    #     items = await db.execute(select(self.model).where(self.model.command_name == command_name))
+    async def get_by_user_id(self, db: AsyncSession, *, user_id: int) -> TrustedModel | None:
+        items = await db.execute(select(self.model).where(self.model.user_id == user_id))
 
-    #     return items.scalars().first()
+        return items.scalars().first()
 
     async def create(self, db: AsyncSession, *, obj_in: TrustedCreate) -> TrustedModel:
-        new_item = await self.create_(db, obj_in=obj_in)
+        await self.create_(db, obj_in=obj_in)
 
-        return new_item
-
-    async def delete(self, db: AsyncSession, *, pk: list[UUID]) -> int:
-        items = await db.execute(delete(self.model).where(self.model.id.in_(pk)))
-
-        return items.rowcount
+    async def delete(self, db: AsyncSession, *, pk: list[int]) -> int:
+        return await self.delete_(db, pk=pk)
 
 
 trusted_dao = TrustedCRUD(TrustedModel)

--- a/api/app/database/crud/trusted.py
+++ b/api/app/database/crud/trusted.py
@@ -1,15 +1,37 @@
-from typing import Annotated, Any
+from collections.abc import Sequence
+from uuid import UUID
 
-from fastapi import Depends
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database.dependencies import get_db_session
+from app.database.crud.base import CRUDBase
+from app.database.models.trusted import TrustedModel
+from app.routers.trusted.schemas import TrustedCreate, TrustedUpdate
 
 
-class TrustedCRUD:
-    def __init__(self, session: Annotated[AsyncSession, Depends(get_db_session)]) -> None:
-        self.session = session
+class TrustedCRUD(CRUDBase[TrustedModel, TrustedCreate, TrustedUpdate]):
+    async def get(self, db: AsyncSession, *, pk: UUID) -> TrustedModel | None:
+        return await self.get_(db, pk=pk)
 
-    async def create_(self, item: Any) -> None:
-        # self.session.add(...(**item.model_dump()))
-        ...
+    async def get_all(self, db: AsyncSession, *, limit: int, offset: int) -> Sequence[TrustedModel]:
+        items = await db.execute(select(self.model).limit(limit).offset(offset))
+
+        return items.scalars().all()
+
+    # async def get_by_command_name(self, db: AsyncSession, *, command_name: str) -> TrustedModel | None:
+    #     items = await db.execute(select(self.model).where(self.model.command_name == command_name))
+
+    #     return items.scalars().first()
+
+    async def create(self, db: AsyncSession, *, obj_in: TrustedCreate) -> TrustedModel:
+        new_item = await self.create_(db, obj_in=obj_in)
+
+        return new_item
+
+    async def delete(self, db: AsyncSession, *, pk: list[UUID]) -> int:
+        items = await db.execute(delete(self.model).where(self.model.id.in_(pk)))
+
+        return items.rowcount
+
+
+trusted_dao = TrustedCRUD(TrustedModel)

--- a/api/app/database/crud/trusted.py
+++ b/api/app/database/crud/trusted.py
@@ -1,0 +1,15 @@
+from typing import Annotated, Any
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.dependencies import get_db_session
+
+
+class TrustedCRUD:
+    def __init__(self, session: Annotated[AsyncSession, Depends(get_db_session)]) -> None:
+        self.session = session
+
+    async def create_(self, item: Any) -> None:
+        # self.session.add(...(**item.model_dump()))
+        ...

--- a/api/app/database/dependencies.py
+++ b/api/app/database/dependencies.py
@@ -1,29 +1,15 @@
 from collections.abc import AsyncGenerator
+from typing import Annotated
 
+from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
 
-async def get_db_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
-    """
-    Create and get database session.
-
-    :param request: current request.
-    :yield: database session.
-    """
-    session: AsyncSession = request.app.state.db_session_factory()
-
-    try:
+async def _get_db_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
+    """Yield a database session, for use with a FastAPI dependency."""
+    async with request.app.state.db_session_factory() as session, session.begin():
         yield session
-    finally:
-        await session.commit()
-        await session.close()
 
 
-# async def _get_db_session() -> AsyncGenerator[AsyncSession, None]:
-#     """Yield a database session, for use with a FastAPI dependency."""
-#     async with Connections.DB_SESSION_MAKER() as session, session.begin():
-#         yield session
-
-
-# DBSession = typing.Annotated[AsyncSession, Depends(_get_db_session)]
+DBSession = Annotated[AsyncSession, Depends(_get_db_session)]

--- a/api/app/database/dependencies.py
+++ b/api/app/database/dependencies.py
@@ -18,3 +18,12 @@ async def get_db_session(request: Request) -> AsyncGenerator[AsyncSession, None]
     finally:
         await session.commit()
         await session.close()
+
+
+# async def _get_db_session() -> AsyncGenerator[AsyncSession, None]:
+#     """Yield a database session, for use with a FastAPI dependency."""
+#     async with Connections.DB_SESSION_MAKER() as session, session.begin():
+#         yield session
+
+
+# DBSession = typing.Annotated[AsyncSession, Depends(_get_db_session)]

--- a/api/app/database/meta.py
+++ b/api/app/database/meta.py
@@ -1,3 +1,10 @@
 import sqlalchemy as sa
 
-meta = sa.MetaData()
+POSTGRES_INDEXES_NAMING_CONVENTION = {
+    "ix": "%(column_0_label)s_idx",
+    "uq": "%(table_name)s_%(column_0_name)s_key",
+    "ck": "%(table_name)s_%(constraint_name)s_check",
+    "fk": "%(table_name)s_%(column_0_name)s_fkey",
+    "pk": "%(table_name)s_pkey",
+}
+meta = sa.MetaData(naming_convention=POSTGRES_INDEXES_NAMING_CONVENTION)

--- a/api/app/database/models/link_map.py
+++ b/api/app/database/models/link_map.py
@@ -20,13 +20,13 @@ class LinkMapChannelModel(Base):
 
     created_at: Mapped[datetime] = mapped_column(DateTime, default=now())
 
-    link_maps: Mapped[list[LinkMapModel]] = relationship(
+    link_maps: Mapped[list[LinkMapConverterModel]] = relationship(
         back_populates="channel_map",
         lazy="joined",
     )
 
 
-class LinkMapModel(Base):
+class LinkMapConverterModel(Base):
     __tablename__ = "link_maps"
 
     id: Mapped[uuid.UUID] = mapped_column(

--- a/api/app/routers/application.py
+++ b/api/app/routers/application.py
@@ -3,15 +3,18 @@ from fastapi.responses import UJSONResponse
 
 from app.routers import api_router
 from app.routers.lifetime import PrometheusMiddleware, lifespan, metrics
+from app.settings import settings
 
 
 def get_app() -> FastAPI:
+    openapi_url = "/api/openapi.json" if settings.environment == "dev" else None
+
     app = FastAPI(
         title="xythrion-api",
         version="0.1.0",
         docs_url="/api/docs",
         redoc_url="/api/redoc",
-        openapi_url="/api/openapi.json",
+        openapi_url=openapi_url,
         default_response_class=UJSONResponse,
         lifespan=lifespan,
     )

--- a/api/app/routers/command_metric/router.py
+++ b/api/app/routers/command_metric/router.py
@@ -1,11 +1,9 @@
-from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
-from sqlalchemy.ext.asyncio import AsyncSession
+from app.database.dependencies import DBSession
+from fastapi import APIRouter, HTTPException, Response, status
 
 from app.database.crud.command_metric import command_metric_dao
-from app.database.dependencies import get_db_session
 from app.database.models.command_metric import CommandMetricModel
 
 from .schemas import CommandMetric, CommandMetricCreate
@@ -20,7 +18,7 @@ router = APIRouter()
     status_code=status.HTTP_200_OK,
 )
 async def get_all_command_metrics(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     limit: int | None = 10,
     offset: int | None = 0,
 ) -> list[CommandMetricModel]:
@@ -33,7 +31,7 @@ async def get_all_command_metrics(
     status_code=status.HTTP_201_CREATED,
 )
 async def create_command_usage_metric(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     command_metric: CommandMetricCreate,
 ) -> None:
     await command_metric_dao.create(session, obj_in=command_metric)
@@ -44,7 +42,7 @@ async def create_command_usage_metric(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def remove_command_usage_metric(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     item_id: UUID,
 ) -> None:
     count = await command_metric_dao.delete(session, pk=[item_id])

--- a/api/app/routers/command_metric/router.py
+++ b/api/app/routers/command_metric/router.py
@@ -1,8 +1,10 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database.crud.command_metric import CommandMetricCRUD
+from app.database.crud.command_metric import command_metric_dao
+from app.database.dependencies import get_db_session
 from app.database.models.command_metric import CommandMetricModel
 
 from .schemas import CommandMetric, CommandMetricCreate
@@ -17,21 +19,20 @@ router = APIRouter()
     status_code=status.HTTP_200_OK,
 )
 async def get_all_command_metrics(
-    crud: Annotated[CommandMetricCRUD, Depends()],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
     limit: int | None = 10,
     offset: int | None = 0,
 ) -> list[CommandMetricModel]:
-    return await crud.get_all_command_metrics(limit=limit, offset=offset)
+    return await command_metric_dao.get_all(session, offset=offset, limit=limit)
 
 
 @router.post(
     "/",
     description="Create a command metric item",
-    response_model=CommandMetric,
     status_code=status.HTTP_201_CREATED,
 )
 async def create_command_usage_metric(
+    session: Annotated[AsyncSession, Depends(get_db_session)],
     command_metric: CommandMetricCreate,
-    crud: Annotated[CommandMetricCRUD, Depends()],
-) -> CommandMetricModel:
-    return await crud.create_command_metric(command_metric)
+) -> None:
+    await command_metric_dao.create(session, obj_in=command_metric)

--- a/api/app/routers/command_metric/router.py
+++ b/api/app/routers/command_metric/router.py
@@ -1,6 +1,7 @@
 from typing import Annotated
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.crud.command_metric import command_metric_dao
@@ -36,3 +37,22 @@ async def create_command_usage_metric(
     command_metric: CommandMetricCreate,
 ) -> None:
     await command_metric_dao.create(session, obj_in=command_metric)
+
+
+@router.delete(
+    "/{item_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def remove_command_usage_metric(
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+    item_id: UUID,
+) -> None:
+    count = await command_metric_dao.delete(session, pk=[item_id])
+
+    if count == 0:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Command metric with ID '{item_id}' does not exist.",
+        )
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/app/routers/command_metric/schemas.py
+++ b/api/app/routers/command_metric/schemas.py
@@ -9,6 +9,10 @@ class CommandMetricCreate(BaseModel):
     successfully_completed: bool
 
 
+class CommandMetricUpdate(BaseModel):
+    pass
+
+
 class CommandMetric(BaseModel):
     id: UUID
     used_at: datetime

--- a/api/app/routers/link_map/router.py
+++ b/api/app/routers/link_map/router.py
@@ -1,12 +1,9 @@
-from typing import Annotated
-
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from app.database.dependencies import DBSession
+from fastapi import APIRouter, HTTPException, Response, status
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database.crud.link_map_channel import link_map_channel_dao
 from app.database.crud.link_map_converter import link_map_converter_dao
-from app.database.dependencies import get_db_session
 from app.database.models.link_map import LinkMapChannelModel, LinkMapConverterModel
 
 from .schemas import (
@@ -26,7 +23,7 @@ router = APIRouter()
     status_code=status.HTTP_200_OK,
 )
 async def get_all_link_map_channels(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
 ) -> list[LinkMapChannelModel]:
     return await link_map_channel_dao.get_all(session)
 
@@ -37,7 +34,7 @@ async def get_all_link_map_channels(
     status_code=status.HTTP_200_OK,
 )
 async def get_one_link_map_channel(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     server_id: int | None = None,
 ) -> LinkMapChannelModel:
     channel = await link_map_channel_dao.get_by_server_id(session, server_id=server_id)
@@ -56,7 +53,7 @@ async def get_one_link_map_channel(
     status_code=status.HTTP_200_OK,
 )
 async def get_all_channel_link_map_converters(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     server_id: int,
     input_channel_id: int,
 ) -> LinkMapChannelConverters | None:
@@ -76,7 +73,7 @@ async def get_all_channel_link_map_converters(
     status_code=status.HTTP_201_CREATED,
 )
 async def create_link_map_channel(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     new_link_map_channel: LinkMapChannelCreate,
 ) -> None:
     channels = await link_map_channel_dao.get_by_server_id(
@@ -99,7 +96,7 @@ async def create_link_map_channel(
     status_code=status.HTTP_201_CREATED,
 )
 async def create_link_map_converter(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     link_map: LinkMapConverterCreate,
 ) -> LinkMapConverterModel:
     if (link_map.to_link is None) == (link_map.xpath is None):
@@ -136,7 +133,7 @@ async def create_link_map_converter(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def remove_link_map_channel(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     id: str,
 ) -> None:
     count = await link_map_channel_dao.delete(session, pk=[id])
@@ -155,7 +152,7 @@ async def remove_link_map_channel(
     status_code=status.HTTP_200_OK,
 )
 async def remove_link_map_converter(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     id: str,
 ) -> None:
     count = await link_map_converter_dao.delete(session, pk=[id])

--- a/api/app/routers/link_map/router.py
+++ b/api/app/routers/link_map/router.py
@@ -1,15 +1,21 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from app.database.crud.link_map_channel import link_map_channel_dao
+from app.database.crud.link_map_converter import link_map_converter_dao
 from app.database.dependencies import get_db_session
 from app.database.models.link_map import LinkMapChannelModel, LinkMapConverterModel
 
-from .schemas import LinkMapChannel, LinkMapChannelCreate, LinkMapConverter, LinkMapConverterCreate
+from .schemas import (
+    LinkMapChannel,
+    LinkMapChannelConverters,
+    LinkMapChannelCreate,
+    LinkMapConverter,
+    LinkMapConverterCreate,
+)
 
 router = APIRouter()
 
@@ -22,9 +28,7 @@ router = APIRouter()
 async def get_all_link_map_channels(
     session: Annotated[AsyncSession, Depends(get_db_session)],
 ) -> list[LinkMapChannelModel]:
-    items = await link_map_channel_dao.get_all(session)
-
-    return list(items)
+    return await link_map_channel_dao.get_all(session)
 
 
 @router.get(
@@ -36,46 +40,35 @@ async def get_one_link_map_channel(
     session: Annotated[AsyncSession, Depends(get_db_session)],
     server_id: int | None = None,
 ) -> LinkMapChannelModel:
-    server_channels = await link_map_channel_dao.get_by_server_id(
-        session,
-        server_id=server_id,
-    )
+    channel = await link_map_channel_dao.get_by_server_id(session, server_id=server_id)
 
-    if server_channels is None:
+    if channel is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"No link map channels could be found for server with ID '{server_id}'",
         )
 
-    return list(server_channels.scalars().fetchall())
+    return channel
 
 
 @router.get(
     "/converters",
-    response_model=list[LinkMapConverter],
     status_code=status.HTTP_200_OK,
 )
 async def get_all_link_map_converters(
     session: Annotated[AsyncSession, Depends(get_db_session)],
-    server_id: int | None = None,
-    input_channel_id: int | None = None,
-) -> list[LinkMapConverterModel]:
-    stmt = select(LinkMapConverterModel)
-
-    if server_id and input_channel_id:
-        stmt = (
-            stmt.join(LinkMapChannelModel, LinkMapConverterModel.channel_map)
-            .where(
-                LinkMapConverterModel.channel_map_server_id == server_id,
-                LinkMapChannelModel.input_channel_id == input_channel_id,
-            )
-            .options(selectinload(LinkMapConverterModel.channel_map))
-        )
+    server_id: int,
+    input_channel_id: int,
+) -> LinkMapChannelConverters:
+    stmt = select(LinkMapChannelModel).where(
+        LinkMapChannelModel.server_id == server_id,
+        LinkMapChannelModel.input_channel_id == input_channel_id,
+    )
 
     items = await session.execute(stmt)
     items.unique()
 
-    return list(items.scalars().fetchall())
+    return items.scalars().one_or_none()
 
 
 @router.post(
@@ -86,12 +79,12 @@ async def create_link_map_channel(
     session: Annotated[AsyncSession, Depends(get_db_session)],
     new_link_map_channel: LinkMapChannelCreate,
 ) -> None:
-    server_channels = await link_map_channel_dao.get_by_server_id(
+    channels = await link_map_channel_dao.get_by_server_id(
         session,
         server_id=new_link_map_channel.server_id,
     )
 
-    if server_channels is not None:
+    if channels is not None:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"Link map channel with ID '{new_link_map_channel.server_id}' already exists",
@@ -122,6 +115,8 @@ async def create_link_map_converter(
     items = await session.execute(stmt)
     items.unique()
 
+    # channel = await link_map_channel_dao.get_by_server_id(session)
+
     if items.scalar_one_or_none() is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -149,7 +144,7 @@ async def remove_link_map_channel(
     if count == 0:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Command metric with ID '{id}' does not exist.",
+            detail=f"Link map channel with ID '{id}' does not exist.",
         )
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)
@@ -157,27 +152,18 @@ async def remove_link_map_channel(
 
 @router.delete(
     "/converters/{id}",
-    response_model=LinkMapConverter,
     status_code=status.HTTP_200_OK,
 )
 async def remove_link_map_converter(
     session: Annotated[AsyncSession, Depends(get_db_session)],
     id: str,
-) -> LinkMapConverterModel:
-    stmt = select(LinkMapConverterModel).where(LinkMapConverterModel.id == id)
+) -> None:
+    count = await link_map_converter_dao.delete(session, pk=[id])
 
-    items = await session.execute(stmt)
-    items.unique()
-
-    if (item := items.scalar_one_or_none()) is None:
+    if count == 0:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Converter by ID '{id}' not found",
+            detail=f"Link map converter with ID '{id}' does not exist.",
         )
 
-    stmt = delete(LinkMapConverterModel).where(LinkMapConverterModel.id == id)
-
-    await session.execute(stmt)
-    await session.commit()
-
-    return item
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/app/routers/link_map/router.py
+++ b/api/app/routers/link_map/router.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import selectinload
 from app.database.dependencies import get_db_session
 from app.database.models.link_map import LinkMapChannelModel, LinkMapConverterModel
 
-from .schemas import LinkMapChannel, LinkMapChannelUpdate, LinkMapConverter, LinkMapConverterCreate
+from .schemas import LinkMapChannel, LinkMapChannelCreate, LinkMapConverter, LinkMapConverterCreate
 
 router = APIRouter()
 
@@ -68,7 +68,7 @@ async def get_all_link_map_converters(
 )
 async def create_link_map_channel(
     session: Annotated[AsyncSession, Depends(get_db_session)],
-    link_map_channel: LinkMapChannelUpdate,
+    link_map_channel: LinkMapChannelCreate,
 ) -> LinkMapChannelModel:
     stmt = select(LinkMapChannelModel).where(
         LinkMapChannelModel.server_id == link_map_channel.server_id,

--- a/api/app/routers/link_map/router.py
+++ b/api/app/routers/link_map/router.py
@@ -1,16 +1,14 @@
-from app.database.dependencies import DBSession
 from fastapi import APIRouter, HTTPException, Response, status
-from sqlalchemy import select
 
 from app.database.crud.link_map_channel import link_map_channel_dao
 from app.database.crud.link_map_converter import link_map_converter_dao
-from app.database.models.link_map import LinkMapChannelModel, LinkMapConverterModel
+from app.database.dependencies import DBSession
+from app.database.models.link_map import LinkMapChannelModel
 
 from .schemas import (
     LinkMapChannel,
     LinkMapChannelConverters,
     LinkMapChannelCreate,
-    LinkMapConverter,
     LinkMapConverterCreate,
 )
 
@@ -56,16 +54,20 @@ async def get_all_channel_link_map_converters(
     session: DBSession,
     server_id: int,
     input_channel_id: int,
-) -> LinkMapChannelConverters | None:
-    stmt = select(LinkMapChannelModel).where(
-        LinkMapChannelModel.server_id == server_id,
-        LinkMapChannelModel.input_channel_id == input_channel_id,
+) -> LinkMapChannelConverters:
+    converters = await link_map_channel_dao.get_converters_for_channel(
+        session,
+        server_id=server_id,
+        input_channel_id=input_channel_id,
     )
 
-    items = await session.execute(stmt)
-    items.unique()
+    if converters is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No link map channels found for input channel with ID '{input_channel_id}'",
+        )
 
-    return items.scalars().one_or_none()
+    return converters
 
 
 @router.post(
@@ -92,40 +94,30 @@ async def create_link_map_channel(
 
 @router.post(
     "/converters",
-    response_model=LinkMapConverter,
     status_code=status.HTTP_201_CREATED,
 )
 async def create_link_map_converter(
     session: DBSession,
     link_map: LinkMapConverterCreate,
-) -> LinkMapConverterModel:
+) -> None:
     if (link_map.to_link is None) == (link_map.xpath is None):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Only populate `to_link` or `xpath`.",
         )
 
-    stmt = select(LinkMapChannelModel).where(
-        LinkMapChannelModel.server_id == link_map.channel_map_server_id,
+    channel = await link_map_channel_dao.get_by_server_id(
+        session,
+        server_id=link_map.channel_map_server_id,
     )
 
-    items = await session.execute(stmt)
-    items.unique()
-
-    # channel = await link_map_channel_dao.get_by_server_id(session)
-
-    if items.scalar_one_or_none() is None:
+    if channel is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Relevant channel map does not exist for server ID '{link_map.channel_map_server_id}'",
         )
 
-    new_item = LinkMapConverterModel(**link_map.model_dump())
-
-    session.add(new_item)
-    await session.flush()
-
-    return new_item
+    await link_map_converter_dao.create(session, obj_in=link_map)
 
 
 @router.delete(

--- a/api/app/routers/link_map/router.py
+++ b/api/app/routers/link_map/router.py
@@ -55,11 +55,11 @@ async def get_one_link_map_channel(
     "/converters",
     status_code=status.HTTP_200_OK,
 )
-async def get_all_link_map_converters(
+async def get_all_channel_link_map_converters(
     session: Annotated[AsyncSession, Depends(get_db_session)],
     server_id: int,
     input_channel_id: int,
-) -> LinkMapChannelConverters:
+) -> LinkMapChannelConverters | None:
     stmt = select(LinkMapChannelModel).where(
         LinkMapChannelModel.server_id == server_id,
         LinkMapChannelModel.input_channel_id == input_channel_id,

--- a/api/app/routers/link_map/schemas.py
+++ b/api/app/routers/link_map/schemas.py
@@ -10,6 +10,10 @@ class LinkMapChannelCreate(BaseModel):
     output_channel_id: int
 
 
+class LinkMapChannelUpdate(BaseModel):
+    pass
+
+
 class LinkMapChannel(BaseModel):
     server_id: int
     input_channel_id: int
@@ -17,14 +21,18 @@ class LinkMapChannel(BaseModel):
     created_at: datetime
 
 
-class LinkMapCreate(BaseModel):
+class LinkMapConverterCreate(BaseModel):
     channel_map_server_id: int
     from_link: str
     to_link: str | None = None
     xpath: str | None = None
 
 
-class LinkMap(BaseModel):
+class LinkMapConverterUpdate(BaseModel):
+    pass
+
+
+class LinkMapConverter(BaseModel):
     id: UUID
     channel_map_server_id: int
     created_at: datetime

--- a/api/app/routers/link_map/schemas.py
+++ b/api/app/routers/link_map/schemas.py
@@ -39,3 +39,7 @@ class LinkMapConverter(BaseModel):
     from_link: str
     to_link: str | None = None
     xpath: str | None = None
+
+
+class LinkMapChannelConverters(LinkMapChannel):
+    link_maps: list[LinkMapConverter]

--- a/api/app/routers/pin/router.py
+++ b/api/app/routers/pin/router.py
@@ -1,10 +1,7 @@
-from typing import Annotated
-
-from fastapi import APIRouter, Depends, HTTPException, status
+from app.database.dependencies import DBSession
+from fastapi import APIRouter, HTTPException, status
 from sqlalchemy import delete, select
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database.dependencies import get_db_session
 from app.database.models.pin import PinModel
 
 from .schemas import Pin, PinCreate
@@ -18,7 +15,7 @@ router = APIRouter()
     status_code=status.HTTP_200_OK,
 )
 async def get_all_pins(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     limit: int | None = 10,
     offset: int | None = 0,
 ) -> list[PinModel]:
@@ -35,7 +32,7 @@ async def get_all_pins(
     status_code=status.HTTP_201_CREATED,
 )
 async def create_pin(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     pin: PinCreate,
 ) -> PinModel:
     stmt = select(PinModel).where(
@@ -66,7 +63,7 @@ async def create_pin(
     status_code=status.HTTP_200_OK,
 )
 async def remove_pin(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     server_id: int,
     channel_id: int,
     message_id: int,

--- a/api/app/routers/pin/schemas.py
+++ b/api/app/routers/pin/schemas.py
@@ -16,3 +16,7 @@ class Pin(PinBase):
 
 class PinCreate(PinBase):
     user_id: int
+
+
+class PinUpdate(BaseModel):
+    pass

--- a/api/app/routers/trusted/router.py
+++ b/api/app/routers/trusted/router.py
@@ -1,10 +1,11 @@
-from app.database.dependencies import DBSession
-from fastapi import APIRouter, HTTPException, status
-from sqlalchemy import delete, select
+from fastapi import APIRouter, HTTPException, Response, status
 
+from app.database.crud.trusted import trusted_dao
+from app.database.dependencies import DBSession
 from app.database.models.trusted import TrustedModel
 
 from .schemas import Trusted, TrustedCreate
+from loguru import logger as log
 
 router = APIRouter()
 
@@ -19,11 +20,7 @@ async def get_all_trusted_users(
     limit: int | None = 10,
     offset: int | None = 0,
 ) -> list[TrustedModel]:
-    stmt = select(TrustedModel).limit(limit).offset(offset)
-
-    items = await session.execute(stmt)
-
-    return list(items.scalars().fetchall())
+    return await trusted_dao.get_all(session, limit=limit, offset=offset)
 
 
 @router.get(
@@ -35,58 +32,52 @@ async def get_trusted_user(
     session: DBSession,
     user_id: int,
 ) -> TrustedModel:
-    stmt = select(TrustedModel).where(TrustedModel.user_id == user_id)
+    user = await trusted_dao.get_by_user_id(session, user_id=user_id)
 
-    items = await session.execute(stmt)
-    items.unique()
-
-    if (item := items.scalar_one_or_none()) is None:
+    if user is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Trusted user with ID '{user_id}' not found",
         )
 
-    return item
+    log.info(user)
+
+    return user
 
 
 @router.post(
     "/",
-    response_model=Trusted,
     status_code=status.HTTP_201_CREATED,
 )
 async def create_trusted_user(
     session: DBSession,
-    trusted: TrustedCreate,
-) -> TrustedModel:
-    stmt = select(TrustedModel).where(TrustedModel.user_id == trusted.user_id)
+    new_user: TrustedCreate,
+) -> None:
+    user = await trusted_dao.get_by_user_id(session, user_id=new_user.user_id)
 
-    items = await session.execute(stmt)
-
-    if items.scalar_one_or_none() is not None:
+    if user is not None:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="User is already trusted",
         )
 
-    new_item = TrustedModel(**trusted.model_dump())
-
-    session.add(new_item)
-    await session.flush()
-
-    return new_item
+    await trusted_dao.create(session, obj_in=new_user)
 
 
 @router.delete(
     "/{user_id}",
-    response_model=Trusted,
-    status_code=status.HTTP_200_OK,
+    status_code=status.HTTP_204_NO_CONTENT,
 )
 async def remove_trusted_user(
     session: DBSession,
     user_id: int,
-) -> TrustedModel:
-    stmt = delete(TrustedModel).where(TrustedModel.user_id == user_id).returning()
+) -> None:
+    count = await trusted_dao.delete(session, pk=[user_id])
 
-    items = await session.execute(stmt)
+    if count == 0:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Trusted user with ID '{user_id}' not found",
+        )
 
-    return items
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/app/routers/trusted/router.py
+++ b/api/app/routers/trusted/router.py
@@ -1,10 +1,7 @@
-from typing import Annotated
-
-from fastapi import APIRouter, Depends, HTTPException, status
+from app.database.dependencies import DBSession
+from fastapi import APIRouter, HTTPException, status
 from sqlalchemy import delete, select
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database.dependencies import get_db_session
 from app.database.models.trusted import TrustedModel
 
 from .schemas import Trusted, TrustedCreate
@@ -18,7 +15,7 @@ router = APIRouter()
     status_code=status.HTTP_200_OK,
 )
 async def get_all_trusted_users(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     limit: int | None = 10,
     offset: int | None = 0,
 ) -> list[TrustedModel]:
@@ -35,7 +32,7 @@ async def get_all_trusted_users(
     status_code=status.HTTP_200_OK,
 )
 async def get_trusted_user(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     user_id: int,
 ) -> TrustedModel:
     stmt = select(TrustedModel).where(TrustedModel.user_id == user_id)
@@ -58,7 +55,7 @@ async def get_trusted_user(
     status_code=status.HTTP_201_CREATED,
 )
 async def create_trusted_user(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     trusted: TrustedCreate,
 ) -> TrustedModel:
     stmt = select(TrustedModel).where(TrustedModel.user_id == trusted.user_id)
@@ -85,7 +82,7 @@ async def create_trusted_user(
     status_code=status.HTTP_200_OK,
 )
 async def remove_trusted_user(
-    session: Annotated[AsyncSession, Depends(get_db_session)],
+    session: DBSession,
     user_id: int,
 ) -> TrustedModel:
     stmt = delete(TrustedModel).where(TrustedModel.user_id == user_id).returning()

--- a/api/app/routers/trusted/schemas.py
+++ b/api/app/routers/trusted/schemas.py
@@ -4,11 +4,15 @@ from uuid import UUID
 from pydantic import BaseModel
 
 
-class TrustedCreate(BaseModel):
-    user_id: int
-
-
 class Trusted(BaseModel):
     id: UUID
     user_id: int
     at: datetime
+
+
+class TrustedCreate(BaseModel):
+    user_id: int
+
+
+class TrustedUpdate(BaseModel):
+    pass

--- a/api/app/tests/conftest.py
+++ b/api/app/tests/conftest.py
@@ -2,6 +2,9 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 import pytest
+from app.database.dependencies import _get_db_session
+from app.database.utils import create_database, drop_database
+from app.routers.application import get_app
 from fastapi import FastAPI
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import (
@@ -11,10 +14,6 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 from testcontainers.postgres import PostgresContainer
-
-from app.database.dependencies import get_db_session
-from app.database.utils import create_database, drop_database
-from app.routers.application import get_app
 
 
 @pytest.fixture(scope="session")
@@ -100,7 +99,7 @@ def fastapi_app(
     :return: fastapi app with mocked dependencies.
     """
     application = get_app()
-    application.dependency_overrides[get_db_session] = lambda: dbsession
+    application.dependency_overrides[_get_db_session] = lambda: dbsession
     return application
 
 

--- a/api/app/tests/routers/test_command_metric.py
+++ b/api/app/tests/routers/test_command_metric.py
@@ -68,3 +68,49 @@ async def test_command_metric_creation_and_list(
     assert used_at
 
     assert d == new_command
+
+
+@pytest.mark.anyio
+async def test_command_metric_creation_and_deletion(
+    fastapi_app: FastAPI,
+    client: AsyncClient,
+    dbsession: AsyncSession,
+) -> None:
+    url = fastapi_app.url_path_for("create_command_usage_metric")
+    new_command = {
+        "command_name": "test_command",
+        "successfully_completed": True,
+    }
+    response = await client.post(url, json=new_command)
+    assert response.status_code == status.HTTP_201_CREATED
+
+    url = fastapi_app.url_path_for("get_all_command_metrics")
+    response = await client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    d = response.json()[0]
+
+    command_id = d.pop("id")
+
+    url = fastapi_app.url_path_for(
+        "remove_command_usage_metric",
+        item_id=command_id,
+    )
+    response = await client.delete(url)
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.anyio
+async def test_command_metric_removal_of_invalid_command(
+    fastapi_app: FastAPI,
+    client: AsyncClient,
+    dbsession: AsyncSession,
+) -> None:
+    url = fastapi_app.url_path_for(
+        "remove_command_usage_metric",
+        item_id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    )
+    response = await client.delete(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/api/app/tests/routers/test_link_map.py
+++ b/api/app/tests/routers/test_link_map.py
@@ -70,11 +70,6 @@ async def test_create_valid_link_map_channel_and_list(
 
     assert response.status_code == status.HTTP_201_CREATED
 
-    data = response.json()
-
-    assert data.pop("created_at")
-    assert data == new_link_map_channel
-
     url = fastapi_app.url_path_for("get_all_link_map_channels")
 
     response = await client.get(url)
@@ -86,7 +81,6 @@ async def test_create_valid_link_map_channel_and_list(
     channel = link_map_channels[0]
 
     assert channel.pop("created_at")
-    assert data == channel
 
 
 @pytest.mark.anyio

--- a/api/app/tests/routers/test_link_map.py
+++ b/api/app/tests/routers/test_link_map.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
+from loguru import logger as log
 
 
 @pytest.mark.anyio
@@ -228,13 +229,17 @@ async def test_create_valid_channel_and_converter_and_search_with_input_channel(
 
     data = response.json()
 
-    assert len(data) == 1
+    assert len(data["link_maps"]) == 1
 
-    d = data[0]
+    d = data["link_maps"][0]
+
+    log.info(d)
 
     assert d.pop("id")
     assert d.pop("created_at")
     assert d.pop("xpath") is None
+
+    # TODO: Attributes
 
     assert d == new_link_map
 

--- a/api/app/tests/routers/test_link_map.py
+++ b/api/app/tests/routers/test_link_map.py
@@ -33,11 +33,7 @@ async def test_check_no_link_map_converters(
         params={"server_id": 1234, "input_channel_id": 1234},
     )
 
-    assert response.status_code == status.HTTP_200_OK
-
-    data = response.json()
-
-    assert data is None
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.anyio
@@ -186,14 +182,6 @@ async def test_create_valid_channel_and_then_valid_link_map_converter(
 
     assert response.status_code == status.HTTP_201_CREATED
 
-    data = response.json()
-
-    assert data.pop("id")
-    assert data.pop("created_at")
-    assert data.pop("xpath") is None
-
-    assert data == new_link_map
-
 
 @pytest.mark.anyio
 async def test_create_valid_channel_and_converter_and_search_with_input_channel(
@@ -270,7 +258,13 @@ async def test_create_valid_channel_and_converter_then_delete_converter_then_lis
 
     assert response.status_code == status.HTTP_201_CREATED
 
-    new_converter = response.json()
+    url = fastapi_app.url_path_for("get_all_channel_link_map_converters")
+    response = await client.get(
+        url,
+        params={"server_id": 321, "input_channel_id": 321},
+    )
+
+    new_converter = response.json()["link_maps"][0]
 
     url = fastapi_app.url_path_for("remove_link_map_converter", id=new_converter["id"])
     response = await client.delete(url)

--- a/api/app/tests/routers/test_pin.py
+++ b/api/app/tests/routers/test_pin.py
@@ -37,12 +37,6 @@ async def test_pin_create_one_returns_valid_response(
     response = await client.post(url, json=new_pin)
     assert response.status_code == status.HTTP_201_CREATED
 
-    data = response.json()
-    created_on = data.pop("created_at")
-
-    assert created_on
-    assert data == new_pin
-
 
 @pytest.mark.anyio
 async def test_pin_create_single_can_be_listed(
@@ -65,7 +59,10 @@ async def test_pin_create_single_can_be_listed(
 
     assert all_pins_response.status_code == status.HTTP_200_OK
 
-    assert pin_response.json() == all_pins_response.json()[0]
+    created_pin = all_pins_response.json()[0]
+
+    for k, v in new_pin.items():
+        assert created_pin[k] == v
 
 
 @pytest.mark.anyio
@@ -129,7 +126,7 @@ async def test_pin_create_and_delete_single_pin_lists_nothing(
     )
     response = await client.delete(url)
 
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == status.HTTP_204_NO_CONTENT
 
     url = fastapi_app.url_path_for("get_all_pins")
     response = await client.get(url)

--- a/api/app/tests/routers/test_trusted.py
+++ b/api/app/tests/routers/test_trusted.py
@@ -46,13 +46,6 @@ async def test_trust_one_user(
     response = await client.post(url, json=new_trusted_user)
     assert response.status_code == status.HTTP_201_CREATED
 
-    data = response.json()
-    user_id, at = data.pop("id"), data.pop("at")
-
-    assert user_id
-    assert at
-    assert data == new_trusted_user
-
 
 @pytest.mark.anyio
 async def test_trust_one_user_then_list(

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -29,8 +29,12 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi>=0.39b0",
     "opentelemetry-distro>=0.43b0",
     "opentelemetry-instrumentation-logging>=0.43b0",
-    "opentelemetry-instrumentation-sqlalchemy>=0.39b0"
+    "opentelemetry-instrumentation-sqlalchemy>=0.39b0",
 ]
+
+[build-system]
+requires = ["pdm-pep517>=1.0.0"]
+build-backend = "pdm.pep517.api"
 
 [tool]
 [tool.pdm]
@@ -68,6 +72,5 @@ test-cov = "python3 -m pytest --cov=./ --cov-report=xml"
 html = "coverage html"
 report = "coverage report --sort=Cover"
 
-[build-system]
-requires = ["pdm-pep517>=1.0.0"]
-build-backend = "pdm.pep517.api"
+[tool.pytest.ini_options]
+filterwarnings = ["ignore::DeprecationWarning"]

--- a/bot/pyproject.toml
+++ b/bot/pyproject.toml
@@ -20,6 +20,10 @@ dependencies = [
     "scipy>=1.12.0",
 ]
 
+[build-system]
+requires = ["pdm-pep517>=1.0.0"]
+build-backend = "pdm.pep517.api"
+
 [tool]
 [tool.pdm]
 [tool.pdm.dev-dependencies]
@@ -48,6 +52,5 @@ test-cov = "python3 -m pytest --cov=./ --cov-report=xml"
 html = "coverage html"
 report = "coverage report"
 
-[build-system]
-requires = ["pdm-pep517>=1.0.0"]
-build-backend = "pdm.pep517.api"
+[tool.pytest.ini_options]
+filterwarnings = ["ignore::DeprecationWarning"]

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -26,6 +26,9 @@ services:
       XYTHRION_API_DB_HOST: "postgres"
       XYTHRION_API_HOST: "0.0.0.0"
 
+    ports:
+    - "127.0.0.1:8001:8001"
+
     volumes:
     - ./api:/api
 


### PR DESCRIPTION
More consistency for replicating SQLAlchemy commands instead of just having a different way of doing things for every one of the endpoints.